### PR TITLE
Work around vagrant ssh bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WATCH_DIRS = site
 GHP_REMOTE = git@github.com:amygriffis/amygriffis.github.io
 NEXT_DEPLOY_DEST = amygriffis@amygriffis.com:next.amygriffis.com/
 DREAM_DEPLOY_DEST = amygriffis@amygriffis.com:amygriffis.com/
-VAGRANT_MAKE = vagrant ssh -- -t make -C /vagrant
+VAGRANT_MAKE = vagrant status | grep -q '^default *running' && vagrant ssh -- -t make -C /vagrant
 THUMBS_BASE = 280
 THUMBS_MULTIPLIERS = 1 2 3
 # use the desired extension on THUMBS rather than the source extension,


### PR DESCRIPTION
This is a workaround for the vagrant ssh bug described at https://github.com/mitchellh/vagrant/issues/8508

It affects our deploy, because `make deploy` doesn't realize the build never ran.

The workaround checks to make sure the vagrant VM is running before attempting ssh. The compound command returns a non-zero exit status if the VM isn't running, and this allows the Makefile to exit rather than continuing with the deploy.